### PR TITLE
ci: include duskmoon_theme_bloc in pub.dev publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,12 +44,12 @@ jobs:
         run: |
           # Publish order respects dependency graph:
           # 1. duskmoon_theme (no deps)
-          # 2. duskmoon_widgets, duskmoon_settings, duskmoon_feedback (depend on theme)
-          # 3. duskmoon_ui (depends on all above)
-          # Note: duskmoon_theme_bloc is publish_to: none — skipped
+          # 2. duskmoon_theme_bloc, duskmoon_widgets, duskmoon_settings, duskmoon_feedback (depend on theme)
+          # 3. duskmoon_ui (depends on all above except theme_bloc)
 
           PUBLISH_ORDER=(
             packages/duskmoon_theme
+            packages/duskmoon_theme_bloc
             packages/duskmoon_widgets
             packages/duskmoon_settings
             packages/duskmoon_feedback

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,6 @@ jobs:
             sed -i '/^publish_to: none$/d' "$pubspec"
           done
 
-          # Re-add publish_to: none for duskmoon_theme_bloc (intentionally not published)
-          sed -i '/^version: .*/a publish_to: none' packages/duskmoon_theme_bloc/pubspec.yaml
-
           # Replace internal dependencies with hosted version constraints
           # Handles both path format and existing hosted format:
           #   duskmoon_theme:        OR   duskmoon_theme: ^x.y.z


### PR DESCRIPTION
## Summary
- Remove the release workflow exclusion that re-added `publish_to: none` for `duskmoon_theme_bloc`
- Add `packages/duskmoon_theme_bloc` to the `PUBLISH_ORDER` array in the publish workflow (after `duskmoon_theme`, which it depends on)

The package already has `publish_to: none` during development (per repo convention), which the release workflow strips from all packages. The only reason it wasn't being published was the explicit re-add in release.yml line 57-58 and its omission from publish.yml.

Fixes #1