### PR TITLE
fix(duskmoon_visualization): widen archive constraint for mason compat

### DIFF
--- a/example/lib/app.dart
+++ b/example/lib/app.dart
@@ -11,12 +11,18 @@ const _fontFallbacks = ['NotoSansMath', 'NotoSansSymbols2'];
 ThemeData _withFontFallbacks(ThemeData theme) {
   TextTheme applyFallback(TextTheme tt) {
     return tt.copyWith(
-      displayLarge: tt.displayLarge?.copyWith(fontFamilyFallback: _fontFallbacks),
-      displayMedium: tt.displayMedium?.copyWith(fontFamilyFallback: _fontFallbacks),
-      displaySmall: tt.displaySmall?.copyWith(fontFamilyFallback: _fontFallbacks),
-      headlineLarge: tt.headlineLarge?.copyWith(fontFamilyFallback: _fontFallbacks),
-      headlineMedium: tt.headlineMedium?.copyWith(fontFamilyFallback: _fontFallbacks),
-      headlineSmall: tt.headlineSmall?.copyWith(fontFamilyFallback: _fontFallbacks),
+      displayLarge:
+          tt.displayLarge?.copyWith(fontFamilyFallback: _fontFallbacks),
+      displayMedium:
+          tt.displayMedium?.copyWith(fontFamilyFallback: _fontFallbacks),
+      displaySmall:
+          tt.displaySmall?.copyWith(fontFamilyFallback: _fontFallbacks),
+      headlineLarge:
+          tt.headlineLarge?.copyWith(fontFamilyFallback: _fontFallbacks),
+      headlineMedium:
+          tt.headlineMedium?.copyWith(fontFamilyFallback: _fontFallbacks),
+      headlineSmall:
+          tt.headlineSmall?.copyWith(fontFamilyFallback: _fontFallbacks),
       titleLarge: tt.titleLarge?.copyWith(fontFamilyFallback: _fontFallbacks),
       titleMedium: tt.titleMedium?.copyWith(fontFamilyFallback: _fontFallbacks),
       titleSmall: tt.titleSmall?.copyWith(fontFamilyFallback: _fontFallbacks),

--- a/example/lib/screens/button/button_screen.dart
+++ b/example/lib/screens/button/button_screen.dart
@@ -99,8 +99,7 @@ class _ButtonBodyState extends State<_ButtonBody> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('DmIconButton',
-                style: Theme.of(context).textTheme.titleLarge),
+            Text('DmIconButton', style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 12),
             Wrap(
               spacing: 8,
@@ -178,8 +177,7 @@ class _ButtonBodyState extends State<_ButtonBody> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Data Display',
-                style: Theme.of(context).textTheme.titleLarge),
+            Text('Data Display', style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 12),
             Text('DmAvatar', style: Theme.of(context).textTheme.titleSmall),
             const SizedBox(height: 8),
@@ -276,8 +274,7 @@ class _InputWidgetsSectionState extends State<_InputWidgetsSection> {
             Text('Input Widgets',
                 style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 12),
-            Text('DmTextField',
-                style: Theme.of(context).textTheme.titleSmall),
+            Text('DmTextField', style: Theme.of(context).textTheme.titleSmall),
             const SizedBox(height: 8),
             DmTextField(
               placeholder: 'Enter text...',
@@ -289,15 +286,13 @@ class _InputWidgetsSectionState extends State<_InputWidgetsSection> {
               enabled: false,
             ),
             const SizedBox(height: 16),
-            Text('DmCheckbox',
-                style: Theme.of(context).textTheme.titleSmall),
+            Text('DmCheckbox', style: Theme.of(context).textTheme.titleSmall),
             const SizedBox(height: 8),
             Row(
               children: [
                 DmCheckbox(
                   value: _checkboxValue,
-                  onChanged: (v) =>
-                      setState(() => _checkboxValue = v ?? false),
+                  onChanged: (v) => setState(() => _checkboxValue = v ?? false),
                 ),
                 const SizedBox(width: 8),
                 Text(_checkboxValue ? 'Checked' : 'Unchecked'),

--- a/example/lib/screens/feedback/feedback_screen.dart
+++ b/example/lib/screens/feedback/feedback_screen.dart
@@ -185,8 +185,7 @@ class _FeedbackBody extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Bottom Sheet',
-                style: Theme.of(context).textTheme.titleLarge),
+            Text('Bottom Sheet', style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 12),
             DmButton(
               onPressed: () => showDmBottomSheetActionList(
@@ -230,8 +229,7 @@ class _FeedbackBody extends StatelessWidget {
                         const SizedBox(width: 12),
                         Text('Delete',
                             style: TextStyle(
-                                color:
-                                    Theme.of(context).colorScheme.error)),
+                                color: Theme.of(context).colorScheme.error)),
                       ],
                     ),
                     onTap: () => Navigator.of(context).pop(),
@@ -265,8 +263,7 @@ class _FeedbackBody extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Icon(Icons.fullscreen,
-                          size: 64,
-                          color: Theme.of(ctx).colorScheme.primary),
+                          size: 64, color: Theme.of(ctx).colorScheme.primary),
                       const SizedBox(height: 16),
                       Text(
                         'This is a fullscreen dialog',

--- a/example/lib/screens/form/form_screen.dart
+++ b/example/lib/screens/form/form_screen.dart
@@ -147,8 +147,7 @@ class _FormBody extends StatelessWidget {
                                 ? const SizedBox(
                                     height: 20,
                                     width: 20,
-                                    child:
-                                        CircularProgressIndicator.adaptive(
+                                    child: CircularProgressIndicator.adaptive(
                                       strokeWidth: 2,
                                     ),
                                   )

--- a/example/lib/screens/markdown/markdown_screen.dart
+++ b/example/lib/screens/markdown/markdown_screen.dart
@@ -154,8 +154,7 @@ x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}
     _streamKey = UniqueKey();
     var index = 0;
     setState(() {});
-    _streamTimer =
-        Timer.periodic(const Duration(milliseconds: 200), (timer) {
+    _streamTimer = Timer.periodic(const Duration(milliseconds: 200), (timer) {
       if (index < _streamingText.length) {
         _streamController!.add(_streamingText[index]);
         index++;
@@ -242,8 +241,7 @@ x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}
               : Center(
                   child: Text(
                     'Press "Start Stream" to begin',
-                    style:
-                        TextStyle(color: colorScheme.onSurfaceVariant),
+                    style: TextStyle(color: colorScheme.onSurfaceVariant),
                   ),
                 ),
         ),

--- a/example/lib/screens/scaffold/scaffold_screen.dart
+++ b/example/lib/screens/scaffold/scaffold_screen.dart
@@ -53,8 +53,7 @@ class _ScaffoldBody extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('DmActionList',
-                style: Theme.of(context).textTheme.titleLarge),
+            Text('DmActionList', style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 4),
             Text(
                 'Renders as popup (small), icon buttons (medium), or text buttons (large)',
@@ -179,8 +178,7 @@ class _ScaffoldBody extends StatelessWidget {
                             child: Text(
                               'DmDrawer',
                               style: TextStyle(
-                                color:
-                                    Theme.of(context).colorScheme.onPrimary,
+                                color: Theme.of(context).colorScheme.onPrimary,
                                 fontSize: 24,
                               ),
                             ),
@@ -281,8 +279,7 @@ class _ScaffoldBody extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('DmScaffold',
-                style: Theme.of(context).textTheme.titleLarge),
+            Text('DmScaffold', style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 4),
             Text(
               'Responsive scaffold: NavigationRail (desktop) / BottomNav (mobile)',
@@ -291,8 +288,7 @@ class _ScaffoldBody extends StatelessWidget {
             const SizedBox(height: 12),
             DmButton(
               onPressed: () => Navigator.of(context).push(
-                MaterialPageRoute(
-                    builder: (_) => const _ScaffoldDemoPage()),
+                MaterialPageRoute(builder: (_) => const _ScaffoldDemoPage()),
               ),
               child: const Text('Open DmScaffold Demo'),
             ),

--- a/example/lib/screens/settings/settings_screen.dart
+++ b/example/lib/screens/settings/settings_screen.dart
@@ -114,8 +114,7 @@ class _SettingsBodyState extends State<_SettingsBody> {
             SettingsTile.slider(
               leading: const Icon(Icons.volume_up),
               title: const Text('Slider Tile'),
-              description:
-                  Text('Value: ${_sliderValue.toStringAsFixed(2)}'),
+              description: Text('Value: ${_sliderValue.toStringAsFixed(2)}'),
               sliderValue: _sliderValue,
               onSliderChanged: (v) => setState(() => _sliderValue = v),
               sliderDivisions: 10,

--- a/example/lib/screens/theme/theme_screen.dart
+++ b/example/lib/screens/theme/theme_screen.dart
@@ -232,8 +232,7 @@ class _ThemeBody extends StatelessWidget {
                     '#${entry.value.toARGB32().toRadixString(16).padLeft(8, '0').substring(2).toUpperCase()}',
                     style: TextStyle(
                       fontSize: 9,
-                      color:
-                          luminance > 0.5 ? Colors.black54 : Colors.white70,
+                      color: luminance > 0.5 ? Colors.black54 : Colors.white70,
                     ),
                   ),
                 ],

--- a/example/lib/screens/visualization/geo_gallery_page.dart
+++ b/example/lib/screens/visualization/geo_gallery_page.dart
@@ -300,7 +300,8 @@ class _GlobeDemoState extends State<_GlobeDemo>
           return LayoutBuilder(
             builder: (context, constraints) {
               // The globe must be circular, so diameter = min(width, height).
-              final scale = min(constraints.maxWidth, constraints.maxHeight) / 2;
+              final scale =
+                  min(constraints.maxWidth, constraints.maxHeight) / 2;
               final globeCenter = dv.Point(scale, scale);
 
               final projection = dv.geoOrthographic(

--- a/example/lib/screens/visualization/interactions_page.dart
+++ b/example/lib/screens/visualization/interactions_page.dart
@@ -681,8 +681,8 @@ class _ZoomPanChartState extends State<_ZoomPanChart> {
                 onScaleUpdate: (d) {
                   setState(() {
                     _translate += d.focalPointDelta;
-                    final newScale = (_scale * (d.scale / _lastScaleValue))
-                        .clamp(0.5, 6.0);
+                    final newScale =
+                        (_scale * (d.scale / _lastScaleValue)).clamp(0.5, 6.0);
                     _scale = newScale;
                     _lastScaleValue = d.scale;
                   });

--- a/example/lib/screens/visualization/visualization_screen.dart
+++ b/example/lib/screens/visualization/visualization_screen.dart
@@ -91,8 +91,7 @@ class _VisualizationBody extends StatelessWidget {
         const _VisualizationModuleCard(
           icon: Icons.public_outlined,
           title: 'Geographic',
-          description:
-              'World map projections, animated globe, regional focus.',
+          description: 'World map projections, animated globe, regional focus.',
           tags: ['Mercator', 'Globe', 'Regions'],
           destination: GeoGalleryPage(),
         ),
@@ -143,8 +142,7 @@ class _VisualizationModuleCard extends StatelessWidget {
                     color: colorScheme.primaryContainer,
                     borderRadius: BorderRadius.circular(16),
                   ),
-                  child:
-                      Icon(icon, color: colorScheme.onPrimaryContainer),
+                  child: Icon(icon, color: colorScheme.onPrimaryContainer),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
@@ -156,8 +154,7 @@ class _VisualizationModuleCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 12),
-            Text(description,
-                style: Theme.of(context).textTheme.bodyMedium),
+            Text(description, style: Theme.of(context).textTheme.bodyMedium),
             const SizedBox(height: 12),
             Wrap(
               spacing: 8,

--- a/example/test/app_test.dart
+++ b/example/test/app_test.dart
@@ -81,7 +81,12 @@ void main() {
 
       expect(find.widgetWithText(AppBar, 'Curated Charts'), findsOneWidget);
       expect(find.text('Line chart'), findsOneWidget);
-      await tester.scrollUntilVisible(find.text('Network graph'), 300);
+      final listScrollable = find.byType(Scrollable).last;
+      await tester.scrollUntilVisible(
+        find.text('Network graph'),
+        300,
+        scrollable: listScrollable,
+      );
       expect(find.text('Network graph'), findsOneWidget);
     });
 

--- a/example/test/app_test.dart
+++ b/example/test/app_test.dart
@@ -94,8 +94,7 @@ void main() {
       await tester.pumpWidget(const MaterialApp(home: GeoMapPage()));
       await tester.pumpAndSettle();
 
-      expect(
-          find.widgetWithText(AppBar, 'Geo Projection Lab'), findsOneWidget);
+      expect(find.widgetWithText(AppBar, 'Geo Projection Lab'), findsOneWidget);
       expect(find.text('Projection'), findsOneWidget);
       expect(find.textContaining('Tap a country'), findsOneWidget);
     });

--- a/packages/duskmoon_adaptive_scaffold/lib/src/adaptive_scaffold.dart
+++ b/packages/duskmoon_adaptive_scaffold/lib/src/adaptive_scaffold.dart
@@ -794,22 +794,21 @@ class _DmAdaptiveScaffoldState extends State<DmAdaptiveScaffold> {
             ),
           },
         ),
-        bottomNavigation:
-            !isDrawerMode
-                ? SlotLayout(
-                    config: <Breakpoint, SlotLayoutConfig>{
-                      widget.smallBreakpoint: SlotLayout.from(
-                        key: const Key('bottomNavigation'),
-                        builder: (_) =>
-                            DmAdaptiveScaffold.standardBottomNavigationBar(
-                          currentIndex: widget.selectedIndex,
-                          destinations: widget.destinations,
-                          onDestinationSelected: widget.onSelectedIndexChange,
-                        ),
-                      ),
-                    },
-                  )
-                : null,
+        bottomNavigation: !isDrawerMode
+            ? SlotLayout(
+                config: <Breakpoint, SlotLayoutConfig>{
+                  widget.smallBreakpoint: SlotLayout.from(
+                    key: const Key('bottomNavigation'),
+                    builder: (_) =>
+                        DmAdaptiveScaffold.standardBottomNavigationBar(
+                      currentIndex: widget.selectedIndex,
+                      destinations: widget.destinations,
+                      onDestinationSelected: widget.onSelectedIndexChange,
+                    ),
+                  ),
+                },
+              )
+            : null,
         body: SlotLayout(
           config: <Breakpoint, SlotLayoutConfig?>{
             Breakpoints.standard: SlotLayout.from(

--- a/packages/duskmoon_form/lib/src/widgets/dm_checkbox_field_bloc_builder.dart
+++ b/packages/duskmoon_form/lib/src/widgets/dm_checkbox_field_bloc_builder.dart
@@ -135,13 +135,12 @@ class DmCheckboxFieldBlocBuilder extends StatelessWidget {
           builder: (context, state) {
             final isEnabled = fieldBlocIsEnabled(
               isEnabled: this.isEnabled,
-              enableOnlyWhenFormBlocCanSubmit:
-                  enableOnlyWhenFormBlocCanSubmit,
+              enableOnlyWhenFormBlocCanSubmit: enableOnlyWhenFormBlocCanSubmit,
               fieldBlocState: state,
             );
 
-            final isMaterial = resolvePlatformStyle(context) ==
-                DmPlatformStyle.material;
+            final isMaterial =
+                resolvePlatformStyle(context) == DmPlatformStyle.material;
             final checkbox = _buildCheckbox(context, state);
             final errorText = Style.getErrorText(
               context: context,
@@ -171,8 +170,7 @@ class DmCheckboxFieldBlocBuilder extends StatelessWidget {
                   data: Theme.of(context)
                       .copyWith(checkboxTheme: fieldTheme.checkboxTheme),
                   child: InputDecorator(
-                    decoration:
-                        Style.inputDecorationWithoutBorder.copyWith(
+                    decoration: Style.inputDecorationWithoutBorder.copyWith(
                       prefixIcon: fieldTheme.controlAffinity! ==
                               FieldBlocBuilderControlAffinity.leading
                           ? checkbox
@@ -201,15 +199,13 @@ class DmCheckboxFieldBlocBuilder extends StatelessWidget {
                     children: [
                       if (isLeading)
                         Padding(
-                          padding:
-                              const EdgeInsets.symmetric(horizontal: 8),
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
                           child: checkbox,
                         ),
                       Expanded(child: bodyWidget),
                       if (!isLeading)
                         Padding(
-                          padding:
-                              const EdgeInsets.symmetric(horizontal: 8),
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
                           child: checkbox,
                         ),
                     ],

--- a/packages/duskmoon_form/lib/src/widgets/dm_dropdown_field_bloc_builder.dart
+++ b/packages/duskmoon_form/lib/src/widgets/dm_dropdown_field_bloc_builder.dart
@@ -179,8 +179,8 @@ class DmDropdownFieldBlocBuilder<Value> extends StatelessWidget {
               isEnabled,
             );
 
-            final isMaterial = resolvePlatformStyle(context) ==
-                DmPlatformStyle.material;
+            final isMaterial =
+                resolvePlatformStyle(context) == DmPlatformStyle.material;
             final dropdown = DmDropdown<Value>(
               value: fieldState.value,
               isExpanded: isExpanded,
@@ -208,8 +208,8 @@ class DmDropdownFieldBlocBuilder<Value> extends StatelessWidget {
                 child: InputDecorator(
                   decoration: decoration,
                   textAlign: textAlign,
-                  isEmpty: fieldState.value == null &&
-                      decoration.hintText == null,
+                  isEmpty:
+                      fieldState.value == null && decoration.hintText == null,
                   child: dropdown,
                 ),
               );

--- a/packages/duskmoon_form/lib/src/widgets/dm_switch_field_bloc_builder.dart
+++ b/packages/duskmoon_form/lib/src/widgets/dm_switch_field_bloc_builder.dart
@@ -144,13 +144,12 @@ class DmSwitchFieldBlocBuilder extends StatelessWidget {
           builder: (context, state) {
             final isEnabled = fieldBlocIsEnabled(
               isEnabled: this.isEnabled,
-              enableOnlyWhenFormBlocCanSubmit:
-                  enableOnlyWhenFormBlocCanSubmit,
+              enableOnlyWhenFormBlocCanSubmit: enableOnlyWhenFormBlocCanSubmit,
               fieldBlocState: state,
             );
 
-            final isMaterial = resolvePlatformStyle(context) ==
-                DmPlatformStyle.material;
+            final isMaterial =
+                resolvePlatformStyle(context) == DmPlatformStyle.material;
             final switchWidget = _buildSwitch(context, state);
             final errorText = Style.getErrorText(
               context: context,
@@ -180,8 +179,7 @@ class DmSwitchFieldBlocBuilder extends StatelessWidget {
                   data: Theme.of(context)
                       .copyWith(switchTheme: fieldTheme.switchTheme!),
                   child: InputDecorator(
-                    decoration:
-                        Style.inputDecorationWithoutBorder.copyWith(
+                    decoration: Style.inputDecorationWithoutBorder.copyWith(
                       prefixIcon: fieldTheme.controlAffinity ==
                               FieldBlocBuilderControlAffinity.leading
                           ? switchWidget
@@ -210,15 +208,13 @@ class DmSwitchFieldBlocBuilder extends StatelessWidget {
                     children: [
                       if (isLeading)
                         Padding(
-                          padding:
-                              const EdgeInsets.symmetric(horizontal: 8),
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
                           child: switchWidget,
                         ),
                       Expanded(child: bodyWidget),
                       if (!isLeading)
                         Padding(
-                          padding:
-                              const EdgeInsets.symmetric(horizontal: 8),
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
                           child: switchWidget,
                         ),
                     ],

--- a/packages/duskmoon_form/lib/src/widgets/flutter_typeahead.dart
+++ b/packages/duskmoon_form/lib/src/widgets/flutter_typeahead.dart
@@ -854,8 +854,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       minLines: widget.textFieldConfiguration.minLines,
       maxLines: widget.textFieldConfiguration.maxLines,
       maxLength: widget.textFieldConfiguration.maxLength,
-      maxLengthEnforcement:
-          widget.textFieldConfiguration.maxLengthEnforcement,
+      maxLengthEnforcement: widget.textFieldConfiguration.maxLengthEnforcement,
       obscureText: widget.textFieldConfiguration.obscureText!,
       onTap: widget.onTap,
       onChanged: _onChanged,

--- a/packages/duskmoon_theme/test/src/adaptive/platform_override_test.dart
+++ b/packages/duskmoon_theme/test/src/adaptive/platform_override_test.dart
@@ -43,7 +43,8 @@ void main() {
       expect(result, DmPlatformStyle.cupertino);
     });
 
-    testWidgets('override forces resolvePlatformStyle to return overridden style',
+    testWidgets(
+        'override forces resolvePlatformStyle to return overridden style',
         (tester) async {
       // Use an Android theme but override to cupertino.
       DmPlatformStyle? resolved;

--- a/packages/duskmoon_visualization/pubspec.yaml
+++ b/packages/duskmoon_visualization/pubspec.yaml
@@ -20,7 +20,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  archive: ^3.6.1
+  archive: ">=3.6.1 <5.0.0"
   duskmoon_theme: ^1.4.1
   vector_math: ^2.2.0
 

--- a/packages/duskmoon_widgets/lib/src/buttons/dm_button.dart
+++ b/packages/duskmoon_widgets/lib/src/buttons/dm_button.dart
@@ -88,8 +88,8 @@ class DmButton extends StatelessWidget with AdaptiveWidget {
         border: Border.all(color: color),
         borderRadius: const BorderRadius.all(Radius.circular(8)),
       ),
-      child: CupertinoButton(
-          sizeStyle: size, onPressed: onPressed, child: child),
+      child:
+          CupertinoButton(sizeStyle: size, onPressed: onPressed, child: child),
     );
   }
 

--- a/packages/duskmoon_widgets/lib/src/inputs/dm_dropdown.dart
+++ b/packages/duskmoon_widgets/lib/src/inputs/dm_dropdown.dart
@@ -117,8 +117,9 @@ class DmDropdown<T> extends StatelessWidget with AdaptiveWidget {
   }
 
   void _showCupertinoPicker(BuildContext context) {
-    final selectedIndex =
-        items.indexWhere((item) => item.value == value).clamp(0, items.length - 1);
+    final selectedIndex = items
+        .indexWhere((item) => item.value == value)
+        .clamp(0, items.length - 1);
 
     showCupertinoModalPopup<void>(
       context: context,
@@ -203,8 +204,9 @@ class _CupertinoPickerSheetState<T> extends State<_CupertinoPickerSheet<T>> {
                   FixedExtentScrollController(initialItem: _selectedIndex),
               itemExtent: 32,
               onSelectedItemChanged: (index) => _selectedIndex = index,
-              children:
-                  widget.items.map((item) => Center(child: item.child)).toList(),
+              children: widget.items
+                  .map((item) => Center(child: item.child))
+                  .toList(),
             ),
           ),
         ],

--- a/packages/duskmoon_widgets/lib/src/navigation/dm_app_bar.dart
+++ b/packages/duskmoon_widgets/lib/src/navigation/dm_app_bar.dart
@@ -97,7 +97,8 @@ class DmAppBar extends StatelessWidget
           title: title,
           leading: effectiveLeading,
           actions: actions,
-          automaticallyImplyLeading: effectiveLeading == null && automaticallyImplyLeading,
+          automaticallyImplyLeading:
+              effectiveLeading == null && automaticallyImplyLeading,
           backgroundColor: backgroundColor,
           foregroundColor: foregroundColor,
           iconTheme: foregroundColor != null
@@ -124,7 +125,8 @@ class DmAppBar extends StatelessWidget
                       Row(mainAxisSize: MainAxisSize.min, children: actions!),
                 )
               : null,
-          automaticallyImplyLeading: effectiveLeading == null && automaticallyImplyLeading,
+          automaticallyImplyLeading:
+              effectiveLeading == null && automaticallyImplyLeading,
           backgroundColor: backgroundColor,
         ),
       DmPlatformStyle.fluent => _buildFluent(context, effectiveLeading),
@@ -148,12 +150,12 @@ class DmAppBar extends StatelessWidget
             children: [
               if (effectiveLeading != null)
                 IconTheme(
-                    data: IconThemeData(color: fgColor), child: effectiveLeading)
+                    data: IconThemeData(color: fgColor),
+                    child: effectiveLeading)
               else if (automaticallyImplyLeading &&
                   Navigator.of(context).canPop())
                 fluent.IconButton(
-                  icon:
-                      Icon(fluent.FluentIcons.back, color: fgColor, size: 16),
+                  icon: Icon(fluent.FluentIcons.back, color: fgColor, size: 16),
                   onPressed: () => Navigator.of(context).maybePop(),
                 ),
               if (title != null)

--- a/packages/duskmoon_widgets/test/src/data_display/dm_data_display_test.dart
+++ b/packages/duskmoon_widgets/test/src/data_display/dm_data_display_test.dart
@@ -128,7 +128,8 @@ void main() {
       expect(find.text('7'), findsOneWidget);
     });
 
-    testWidgets('renders dot InfoBadge without label on Fluent', (tester) async {
+    testWidgets('renders dot InfoBadge without label on Fluent',
+        (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
@@ -238,7 +239,8 @@ void main() {
       expect(find.text('iOS Tag'), findsOneWidget);
     });
 
-    testWidgets('renders ToggleButton on Fluent when selectable', (tester) async {
+    testWidgets('renders ToggleButton on Fluent when selectable',
+        (tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(


### PR DESCRIPTION
## Summary
- Widen `archive` dependency from `^3.6.1` to `>=3.6.1 <5.0.0`
- Resolves version conflict with `mason >=0.1.1` which requires `archive ^4.0.0`
- Only API used (`GZipDecoder().decodeBytes()`) is unchanged across v3 and v4

Fixes #8