### PR TITLE
fix: defer chat bubble stream notifications

### DIFF
--- a/packages/duskmoon_widgets/lib/src/chat/bubble/_bubble_stream_coordinator.dart
+++ b/packages/duskmoon_widgets/lib/src/chat/bubble/_bubble_stream_coordinator.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 /// Signals cross-block events within a single bubble — specifically, the
@@ -6,12 +7,33 @@ import 'package:flutter/widgets.dart';
 /// toggled yet.
 class BubbleStreamCoordinator extends ChangeNotifier {
   bool _textStarted = false;
+  bool _notifyScheduled = false;
+  bool _disposed = false;
+
   bool get textStarted => _textStarted;
 
   void markTextStarted() {
-    if (_textStarted) return;
+    if (_textStarted || _disposed) return;
     _textStarted = true;
-    notifyListeners();
+    if (SchedulerBinding.instance.schedulerPhase !=
+        SchedulerPhase.persistentCallbacks) {
+      notifyListeners();
+      return;
+    }
+    if (_notifyScheduled) return;
+    _notifyScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _notifyScheduled = false;
+      if (!_disposed) {
+        notifyListeners();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
   }
 }
 

--- a/packages/duskmoon_widgets/test/chat/dm_chat_bubble_test.dart
+++ b/packages/duskmoon_widgets/test/chat/dm_chat_bubble_test.dart
@@ -91,5 +91,28 @@ void main() {
       expect(find.byKey(const ValueKey('user-avatar')), findsOneWidget);
       expect(find.byKey(const ValueKey('user-header')), findsOneWidget);
     });
+
+    testWidgets('does not notify stream scope during a parent rebuild',
+        (tester) async {
+      DmChatMessage message(String text) => DmChatMessage(
+            id: 'a1',
+            role: DmChatRole.assistant,
+            blocks: [
+              const DmChatThinkingBlock(text: 'reasoning'),
+              DmChatTextBlock(text: text),
+            ],
+          );
+
+      await pumpThemed(
+        tester,
+        DmChatBubble(message: message('partial streamed text')),
+      );
+      await pumpThemed(
+        tester,
+        DmChatBubble(message: message('partial streamed text updated')),
+      );
+
+      expect(tester.takeException(), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- defer BubbleStreamCoordinator listener notifications during Flutter persistent frame callbacks
- add a regression test covering chat bubble parent rebuilds with thinking and text blocks

Fixes #10