### PR TITLE
fix: support file_picker 11 in widgets

### DIFF
--- a/packages/duskmoon_widgets/lib/src/chat/input/_attach_button.dart
+++ b/packages/duskmoon_widgets/lib/src/chat/input/_attach_button.dart
@@ -17,7 +17,7 @@ class AttachButton extends StatelessWidget {
   final bool enabled;
 
   Future<void> _pick() async {
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       allowMultiple: true,
       withData: true,
     );

--- a/packages/duskmoon_widgets/pubspec.yaml
+++ b/packages/duskmoon_widgets/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   flutter_math_fork: ^0.7.4
   url_launcher: ^6.3.0
   fluent_ui: ^4.15.1
-  file_picker: ^8.1.2
+  file_picker: ^11.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- update duskmoon_widgets to depend on file_picker ^11.0.2
- migrate AttachButton to the file_picker 11 static pickFiles API

Fixes #12