### PR TITLE
fix: render dropdown labels on adaptive platforms

### DIFF
--- a/packages/duskmoon_form/lib/src/blocs/form/form_state.dart
+++ b/packages/duskmoon_form/lib/src/blocs/form/form_state.dart
@@ -656,8 +656,7 @@ class FormBlocLoading<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toLoadFailed].
 class FormBlocLoadFailed<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final FailureResponse? failureResponse;
 
   bool get hasFailureResponse => failureResponse != null;
@@ -717,8 +716,7 @@ class FormBlocLoaded<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toSubmitting].
 class FormBlocSubmitting<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final bool isCanceling;
   final double progress;
 
@@ -763,8 +761,7 @@ class FormBlocSubmitting<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toSuccess].
 class FormBlocSuccess<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final SuccessResponse? successResponse;
   final bool canSubmitAgain;
   final int stepCompleted;
@@ -809,8 +806,7 @@ class FormBlocSuccess<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toFailure].
 class FormBlocFailure<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final FailureResponse? failureResponse;
 
   bool get hasFailureResponse => failureResponse != null;
@@ -923,8 +919,7 @@ class FormBlocDeleting<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toFailure].
 class FormBlocDeleteFailed<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final FailureResponse? failureResponse;
 
   bool get hasFailureResponse => failureResponse != null;
@@ -960,8 +955,7 @@ class FormBlocDeleteFailed<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toSuccess].
 class FormBlocDeleteSuccessful<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final SuccessResponse? successResponse;
 
   bool get hasSuccessResponse => successResponse != null;
@@ -997,8 +991,7 @@ class FormBlocDeleteSuccessful<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toUpdatingFields].
 class FormBlocUpdatingFields<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final double progress;
 
   FormBlocUpdatingFields({

--- a/packages/duskmoon_form/lib/src/widgets/dm_dropdown_field_bloc_builder.dart
+++ b/packages/duskmoon_form/lib/src/widgets/dm_dropdown_field_bloc_builder.dart
@@ -1,5 +1,5 @@
 import 'package:duskmoon_widgets/duskmoon_widgets.dart'
-    show DmDropdown, DmDropdownItem, DmPlatformStyle, resolvePlatformStyle;
+    show DmDropdown, DmDropdownItem;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -179,8 +179,6 @@ class DmDropdownFieldBlocBuilder<Value> extends StatelessWidget {
               isEnabled,
             );
 
-            final isMaterial =
-                resolvePlatformStyle(context) == DmPlatformStyle.material;
             final dropdown = DmDropdown<Value>(
               value: fieldState.value,
               isExpanded: isExpanded,
@@ -202,44 +200,14 @@ class DmDropdownFieldBlocBuilder<Value> extends StatelessWidget {
               }).toList(),
             );
 
-            if (isMaterial) {
-              return DefaultFieldBlocBuilderPadding(
-                padding: padding,
-                child: InputDecorator(
-                  decoration: decoration,
-                  textAlign: textAlign,
-                  isEmpty:
-                      fieldState.value == null && decoration.hintText == null,
-                  child: dropdown,
-                ),
-              );
-            }
-
-            final errorText = Style.getErrorText(
-              context: context,
-              errorBuilder: errorBuilder,
-              fieldBlocState: fieldState,
-              fieldBloc: selectFieldBloc,
-            );
             return DefaultFieldBlocBuilderPadding(
               padding: padding,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  dropdown,
-                  if (errorText != null)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: Text(
-                        errorText,
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.error,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ),
-                ],
+              child: InputDecorator(
+                decoration: decoration,
+                textAlign: textAlign,
+                isEmpty:
+                    fieldState.value == null && decoration.hintText == null,
+                child: dropdown,
               ),
             );
           },

--- a/packages/duskmoon_form/pubspec.yaml
+++ b/packages/duskmoon_form/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   duskmoon_theme: ^1.7.0
   duskmoon_widgets: ^1.7.0
-  fluent_ui: ">=4.9.1"
+  fluent_ui: ">=4.9.1 <4.16.0"
   bloc: ^9.0.0
   flutter_bloc: ^9.0.0
   rxdart: ^0.28.0

--- a/packages/duskmoon_form/test/src/widgets/dm_dropdown_field_bloc_builder_test.dart
+++ b/packages/duskmoon_form/test/src/widgets/dm_dropdown_field_bloc_builder_test.dart
@@ -1,0 +1,46 @@
+import 'package:duskmoon_form/duskmoon_form.dart';
+import 'package:duskmoon_theme/duskmoon_theme.dart';
+import 'package:duskmoon_widgets/duskmoon_widgets.dart' show DmDropdown;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child, {ThemeData? theme}) {
+  return MaterialApp(
+    theme: theme ?? DmThemeData.sunshine(),
+    themeAnimationDuration: Duration.zero,
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  group('DmDropdownFieldBlocBuilder', () {
+    testWidgets('renders decoration label on macOS platform', (tester) async {
+      final bloc = SelectFieldBloc<String, dynamic>(
+        initialValue: 'camera1',
+        items: const ['camera1'],
+      );
+      addTearDown(bloc.close);
+
+      await tester.pumpWidget(
+        _wrap(
+          DmDropdownFieldBlocBuilder<String>(
+            selectFieldBloc: bloc,
+            decoration: const InputDecoration(
+              labelText: 'Video Device',
+              border: OutlineInputBorder(),
+            ),
+            itemBuilder: (context, value) => FieldItem(child: Text(value)),
+          ),
+          theme: DmThemeData.sunshine().copyWith(
+            platform: TargetPlatform.macOS,
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 20));
+
+      expect(find.byType(DmDropdown<String>), findsOneWidget);
+      expect(find.text('Video Device'), findsOneWidget);
+      expect(find.text('camera1'), findsOneWidget);
+    });
+  });
+}

--- a/packages/duskmoon_widgets/pubspec.yaml
+++ b/packages/duskmoon_widgets/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   highlighting: ^0.9.0+11.8.0
   flutter_math_fork: ^0.7.4
   url_launcher: ^6.3.0
-  fluent_ui: ^4.15.1
+  fluent_ui: ">=4.15.1 <4.16.0"
   file_picker: ^11.0.2
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Wrap adaptive dropdown fields with the shared InputDecorator path so labels and selected values render on non-Material platforms
- Add a macOS regression widget test for dropdown field labels
- Keep current dependency resolution compatible with the repo Flutter SDK and analyzer

Fixes #15