### PR TITLE
fix: preserve dark Cupertino dialog surface

### DIFF
--- a/packages/duskmoon_feedback/lib/src/dialog.dart
+++ b/packages/duskmoon_feedback/lib/src/dialog.dart
@@ -51,14 +51,21 @@ Future<T?> showDmDialog<T>({
   List<Widget>? actions,
 }) {
   final style = resolvePlatformStyle(context);
+  final materialTheme = Theme.of(context);
+  final cupertinoTheme = CupertinoTheme.of(context);
+  final cupertinoBrightness =
+      cupertinoTheme.brightness ?? materialTheme.brightness;
   return showDialog<T>(
     context: context,
-    builder: (context) {
+    builder: (_) {
       if (style == DmPlatformStyle.cupertino) {
-        return CupertinoAlertDialog(
-          title: title,
-          content: content,
-          actions: actions ?? const [],
+        return CupertinoTheme(
+          data: cupertinoTheme.copyWith(brightness: cupertinoBrightness),
+          child: CupertinoAlertDialog(
+            title: title,
+            content: content,
+            actions: actions ?? const [],
+          ),
         );
       }
       return AlertDialog(

--- a/packages/duskmoon_feedback/test/src/dialog_test.dart
+++ b/packages/duskmoon_feedback/test/src/dialog_test.dart
@@ -1,4 +1,6 @@
 import 'package:duskmoon_feedback/duskmoon_feedback.dart';
+import 'package:duskmoon_theme/duskmoon_theme.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -37,6 +39,46 @@ void main() {
 
       expect(find.text('Dialog Title'), findsOneWidget);
       expect(find.text('Dialog Content'), findsOneWidget);
+    });
+
+    testWidgets('uses dark Cupertino theme for dark adaptive dialogs', (
+      WidgetTester tester,
+    ) async {
+      const Key tapTarget = Key('tap-target');
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(),
+          home: DmPlatformOverride(
+            style: DmPlatformStyle.cupertino,
+            child: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    showDmDialog(
+                      context: context,
+                      title: const Text('Dark Dialog'),
+                      content: const Text('Dark Content'),
+                    );
+                  },
+                  behavior: HitTestBehavior.opaque,
+                  child: const SizedBox(
+                    height: 100.0,
+                    width: 100.0,
+                    key: tapTarget,
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(tapTarget), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoAlertDialog), findsOneWidget);
+      final dialogContext = tester.element(find.byType(CupertinoAlertDialog));
+      expect(CupertinoTheme.brightnessOf(dialogContext), Brightness.dark);
     });
 
     testWidgets('displays action buttons', (WidgetTester tester) async {

--- a/packages/duskmoon_form/lib/src/blocs/form/form_state.dart
+++ b/packages/duskmoon_form/lib/src/blocs/form/form_state.dart
@@ -656,8 +656,7 @@ class FormBlocLoading<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toLoadFailed].
 class FormBlocLoadFailed<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final FailureResponse? failureResponse;
 
   bool get hasFailureResponse => failureResponse != null;
@@ -717,8 +716,7 @@ class FormBlocLoaded<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toSubmitting].
 class FormBlocSubmitting<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final bool isCanceling;
   final double progress;
 
@@ -763,8 +761,7 @@ class FormBlocSubmitting<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toSuccess].
 class FormBlocSuccess<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final SuccessResponse? successResponse;
   final bool canSubmitAgain;
   final int stepCompleted;
@@ -809,8 +806,7 @@ class FormBlocSuccess<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toFailure].
 class FormBlocFailure<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final FailureResponse? failureResponse;
 
   bool get hasFailureResponse => failureResponse != null;
@@ -923,8 +919,7 @@ class FormBlocDeleting<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toFailure].
 class FormBlocDeleteFailed<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final FailureResponse? failureResponse;
 
   bool get hasFailureResponse => failureResponse != null;
@@ -960,8 +955,7 @@ class FormBlocDeleteFailed<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toSuccess].
 class FormBlocDeleteSuccessful<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final SuccessResponse? successResponse;
 
   bool get hasSuccessResponse => successResponse != null;
@@ -997,8 +991,7 @@ class FormBlocDeleteSuccessful<SuccessResponse, FailureResponse>
 /// {@macro form_bloc.form_state.notUseThisClassInsteadUseToMethod}
 /// [FormBlocState.toUpdatingFields].
 class FormBlocUpdatingFields<SuccessResponse, FailureResponse>
-    extends FormBlocState<SuccessResponse, FailureResponse>
-    with EquatableMixin {
+    extends FormBlocState<SuccessResponse, FailureResponse> {
   final double progress;
 
   FormBlocUpdatingFields({

--- a/packages/duskmoon_form/pubspec.yaml
+++ b/packages/duskmoon_form/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   duskmoon_theme: ^1.7.0
   duskmoon_widgets: ^1.7.0
-  fluent_ui: ">=4.9.1"
+  fluent_ui: ">=4.9.1 <4.16.0"
   bloc: ^9.0.0
   flutter_bloc: ^9.0.0
   rxdart: ^0.28.0

--- a/packages/duskmoon_widgets/pubspec.yaml
+++ b/packages/duskmoon_widgets/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   highlighting: ^0.9.0+11.8.0
   flutter_math_fork: ^0.7.4
   url_launcher: ^6.3.0
-  fluent_ui: ^4.15.1
+  fluent_ui: ">=4.15.1 <4.16.0"
   file_picker: ^11.0.2
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- bridge Material/DuskMoon brightness into Cupertino dialogs
- add a Cupertino dark-theme regression widget test
- keep the workspace dependency baseline compatible with current Flutter

Fixes #16