### PR TITLE
fix: support local navigator dialogs

### DIFF
--- a/packages/duskmoon_feedback/lib/src/dialog.dart
+++ b/packages/duskmoon_feedback/lib/src/dialog.dart
@@ -49,14 +49,15 @@ Future<T?> showDmDialog<T>({
   required Widget title,
   required Widget content,
   List<Widget>? actions,
+  bool useRootNavigator = true,
 }) {
   final style = resolvePlatformStyle(context);
   final materialTheme = Theme.of(context);
   final cupertinoTheme = CupertinoTheme.of(context);
-  final cupertinoBrightness =
-      cupertinoTheme.brightness ?? materialTheme.brightness;
+  final cupertinoBrightness = materialTheme.brightness;
   return showDialog<T>(
     context: context,
+    useRootNavigator: useRootNavigator,
     builder: (_) {
       if (style == DmPlatformStyle.cupertino) {
         return CupertinoTheme(

--- a/packages/duskmoon_feedback/test/src/dialog_test.dart
+++ b/packages/duskmoon_feedback/test/src/dialog_test.dart
@@ -81,6 +81,57 @@ void main() {
       expect(CupertinoTheme.brightnessOf(dialogContext), Brightness.dark);
     });
 
+    testWidgets('can keep Cupertino dialogs on a nested local navigator', (
+      WidgetTester tester,
+    ) async {
+      final outerNavigatorKey = GlobalKey<NavigatorState>();
+      final innerNavigatorKey = GlobalKey<NavigatorState>();
+      const Key tapTarget = Key('tap-target');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: outerNavigatorKey,
+          theme: ThemeData.light(),
+          home: MaterialApp(
+            navigatorKey: innerNavigatorKey,
+            theme: DmThemeData.moonlight(),
+            home: DmPlatformOverride(
+              style: DmPlatformStyle.cupertino,
+              child: Builder(
+                builder: (BuildContext context) {
+                  return GestureDetector(
+                    onTap: () {
+                      showDmDialog(
+                        context: context,
+                        title: const Text('Run Deploy'),
+                        content: const Text('Branch/Tag'),
+                        useRootNavigator: false,
+                      );
+                    },
+                    behavior: HitTestBehavior.opaque,
+                    child: const SizedBox(
+                      height: 100.0,
+                      width: 100.0,
+                      key: tapTarget,
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(tapTarget), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoAlertDialog), findsOneWidget);
+      final dialogContext = tester.element(find.byType(CupertinoAlertDialog));
+      expect(CupertinoTheme.brightnessOf(dialogContext), Brightness.dark);
+      expect(innerNavigatorKey.currentState!.canPop(), isTrue);
+      expect(outerNavigatorKey.currentState!.canPop(), isFalse);
+    });
+
     testWidgets('displays action buttons', (WidgetTester tester) async {
       const Key tapTarget = Key('tap-target');
       await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- expose useRootNavigator on showDmDialog for nested apps
- preserve source Material/DuskMoon brightness for Cupertino dialogs
- add a nested MaterialApp regression widget test
- keep the workspace dependency baseline compatible with current Flutter

Fixes #17